### PR TITLE
Force Deezer as primary with Amazon Music and YouTube Music as fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Additionally this unoffical fork of Metrolist is completely different backend an
 
 MetroFuse is a fork of Metrolist focused on combining multiple music frontpages and playback providers in one Android app. It keeps the familiar Material 3 player, library, lyrics, queue, widgets, and playlist tools while adding source switching for different discovery and playback workflows.
 
-The default playback path is Deezer-first, with other enabled providers used only when the primary source cannot produce a playable stream.
+The default playback path is Deezer-first, with Amazon Music and YouTube Music as fallback providers when Deezer cannot produce a playable stream.
 Im back :D
 ---
 

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -136,13 +136,9 @@ fun AudioProviderOrderItem.isPlaybackProvider(): Boolean =
 object AudioProviderOrder {
     val Default: List<AudioProviderOrderItem> =
         listOf(
-            AudioProviderOrderItem.SOUNDCLOUD,
-            AudioProviderOrderItem.TIDAL,
             AudioProviderOrderItem.DEEZER,
             AudioProviderOrderItem.AMAZON_MUSIC,
-            AudioProviderOrderItem.INSTAGRAM,
             AudioProviderOrderItem.YOUTUBE_MUSIC,
-            AudioProviderOrderItem.QOBUZ,
         )
 
     fun serialize(providers: List<AudioProviderOrderItem>): String =


### PR DESCRIPTION
- Reorder AudioProviderOrder.Default to prioritize Deezer first
- Remove SoundCloud, TIDAL, Instagram, and Qobuz from default provider list
- Keep Amazon Music and YouTube Music as fallback providers
- Update README to reflect the new provider order

## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->

## Cause
<!-- Explain the root cause of the problem -->

## Solution
<!-- List the changes made to fix the issue -->
- 

## Testing
<!-- Describe how the changes were tested -->

## Related Issues
<!-- List any related issues or PRs -->
- Closes #
- Related to #
